### PR TITLE
Simple server for previewing

### DIFF
--- a/scarab/__init__.py
+++ b/scarab/__init__.py
@@ -3,4 +3,5 @@ from . import caches
 from . import helpers
 from . import loaders
 from . import renderers
+from . import servers
 from . import writers

--- a/scarab/servers.py
+++ b/scarab/servers.py
@@ -9,7 +9,7 @@ class PreviewServer:
     def __init__(self, port):
         """Create a new PreviewServer."""
         server_address = ('localhost', port)
-        self._server = server.HTTPServer(server_address, PreviewHandler)
+        self._server = server.HTTPServer(server_address, _PreviewHandler)
         self._server.pages = {}
 
     def set_pages(self, pages):
@@ -28,7 +28,7 @@ class PreviewServer:
         self._server.shutdown()
 
 
-class PreviewHandler(server.BaseHTTPRequestHandler):
+class _PreviewHandler(server.BaseHTTPRequestHandler):
 
     """Handler for the PreviewServer."""
 

--- a/scarab/servers.py
+++ b/scarab/servers.py
@@ -1,0 +1,48 @@
+"""Scarab servers."""
+from http import server
+
+
+class PreviewServer:
+
+    """A server for previewing pages locally."""
+
+    def __init__(self, port):
+        """Create a new PreviewServer."""
+        server_address = ('', port)
+        self._server = server.HTTPServer(server_address, PreviewHandler)
+        self._server.pages = {}
+
+    def set_pages(self, pages):
+        """Set the servers pages."""
+        self._server.pages = {
+            '/' + page['destination']: page['bytes']
+            for page in pages
+        }
+
+    def serve_forever(self):
+        """Serve forever, just like the inner server."""
+        self._server.serve_forever()
+
+
+class PreviewHandler(server.BaseHTTPRequestHandler):
+
+    """Handler for the PreviewServer."""
+
+    def load_page(self, path):
+        """Load a page, or raise KeyError."""
+        if path.endswith('/'):
+            path = path + 'index.html'
+
+        return self.server.pages[path]
+
+    def do_GET(self):
+        """Handle GET requests."""
+        try:
+            content = self.load_page(self.path)
+        except KeyError:
+            self.send_response(404)
+            self.end_headers()
+        else:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(content)

--- a/scarab/servers.py
+++ b/scarab/servers.py
@@ -23,6 +23,10 @@ class PreviewServer:
         """Serve forever, just like the inner server."""
         self._server.serve_forever()
 
+    def shutdown(self):
+        """Do a clean shutdown of the inner server."""
+        self._server.shutdown()
+
 
 class PreviewHandler(server.BaseHTTPRequestHandler):
 

--- a/scarab/servers.py
+++ b/scarab/servers.py
@@ -8,7 +8,7 @@ class PreviewServer:
 
     def __init__(self, port):
         """Create a new PreviewServer."""
-        server_address = ('', port)
+        server_address = ('localhost', port)
         self._server = server.HTTPServer(server_address, PreviewHandler)
         self._server.pages = {}
 

--- a/test/test_servers.py
+++ b/test/test_servers.py
@@ -1,0 +1,23 @@
+"""Tests for the servers module."""
+from scarab import servers
+
+
+def test_preview_server():
+    """Simple tests for the PreviewServer."""
+    server = servers.PreviewServer(8000)
+    assert server._server.pages == {}
+
+    pages = [
+        {
+            'destination': 'some/path',
+            'bytes': b'some bytes',
+        },
+    ]
+
+    server.set_pages(pages)
+
+    simplified_pages = {
+        '/' + page['destination']: page['bytes']
+        for page in pages
+    }
+    assert server._server.pages == simplified_pages


### PR DESCRIPTION
Unlike other attempts, this one does not rely on files on the
filesystem, but instead keeps pages in memory. Which is fine for
smaller sites.
- [x] Don't expose the handler on export, it's a bit messy.
- [x] ~~Maybe a different api to start the server with.~~
- [x] Testing would be nice, but how to test this?
