### PR TITLE
Better renderer

### DIFF
--- a/scarab/renderers.py
+++ b/scarab/renderers.py
@@ -21,3 +21,13 @@ class Renderer:
     def filters(self):
         """Expose the jinja filters for easy custom filters."""
         return self.env.filters
+
+    @property
+    def globals(self):
+        """Expose the jinja globals for easy extension."""
+        return self.env.globals
+
+    @property
+    def tests(self):
+        """Expose the jinja tests for easy extention."""
+        return self.env.tests

--- a/scarab/renderers.py
+++ b/scarab/renderers.py
@@ -11,9 +11,9 @@ class Renderer:
         """Make a new template renderer."""
         self.env = Environment(loader=FileSystemLoader(template_directory))
 
-    def __call__(self, page, **extras):
+    def __call__(self, page, template_name, **extras):
         """Render something."""
-        template = self.env.get_template(page['template'])
+        template = self.env.get_template(template_name)
         return template.render(page=page, **extras)
 
     @property

--- a/scarab/renderers.py
+++ b/scarab/renderers.py
@@ -7,15 +7,14 @@ class Renderer:
 
     """A simple template renderer."""
 
-    def __init__(self, template_directory, site_globals):
+    def __init__(self, template_directory):
         """Make a new template renderer."""
         self.env = Environment(loader=FileSystemLoader(template_directory))
-        self.site_globals = site_globals
 
-    def __call__(self, page):
+    def __call__(self, page, **extras):
         """Render something."""
         template = self.env.get_template(page['template'])
-        return template.render(page=page, **self.site_globals)
+        return template.render(page=page, **extras)
 
     @property
     def filters(self):


### PR DESCRIPTION
This cleans up the `Renderer` class a bit, no more `site_globals`, but instead expose more parts of the internal jinja2 `Environment`.
- [x] Implement a good way to dictate what template goes with what page.
